### PR TITLE
Torrent downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 * Run all unit tests. Some flaky timeouts are possible, unfortunately.
 * Run `ShowPeersForTorrentApp` and pass path to some `.torrent` file as a parameter. For example, you can download [Debian ISO torrent](http://mirror.yandex.ru/debian-cd/current/amd64/bt-cd/) and the app will print you list of all peers reported by the tracker, as well as what pieces peers report to have.
+* Run `DownloaderTorrentApp`, pass path to some `.torrent` file (it should contain a single file) and an output file. The program should save the torrent into the file. Note that it may be significantly slower than your standard client.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 * Run all unit tests. Some flaky timeouts are possible, unfortunately.
 * Run `ShowPeersForTorrentApp` and pass path to some `.torrent` file as a parameter. For example, you can download [Debian ISO torrent](http://mirror.yandex.ru/debian-cd/current/amd64/bt-cd/) and the app will print you list of all peers reported by the tracker, as well as what pieces peers report to have.
-* Run `DownloaderTorrentApp`, pass path to some `.torrent` file (it should contain a single file) and an output file. The program should save the torrent into the file. Note that it may be significantly slower than your standard client.
+* Run `DownloaderTorrentApp`, pass path to some `.torrent` file (it should contain a single file) and an output file. The program should save the torrent into the file. Note that it may be significantly slower than your standard client (I had 0.5 MB/second on localhost).

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,6 +27,9 @@
 
     <logger name="net.yeputons.spbau.fall2017.scala.torrentclient" level="DEBUG"/>
 
+    <logger name="net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerConnection" level="INFO"/>
+    <logger name="net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerHandler" level="INFO"/>
+
     <root level="INFO">
         <appender-ref ref="StandardStdout" />
         <appender-ref ref="AkkaStdout" />

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
@@ -1,0 +1,142 @@
+package net.yeputons.spbau.fall2017.scala.torrentclient
+
+import java.io.{File, RandomAccessFile}
+
+import akka.actor.SupervisorStrategy.Restart
+import akka.actor.{
+  Actor,
+  ActorLogging,
+  ActorRef,
+  OneForOneStrategy,
+  Props,
+  SupervisorStrategy,
+  Terminated,
+  Timers
+}
+import akka.util.ByteString
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.{
+  PeerSwarmHandler,
+  PieceDownloader
+}
+import net.yeputons.spbau.fall2017.scala.torrentclient.FileTorrentDownloader._
+import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.{
+  GetPeers,
+  PeersListResponse,
+  SubscribeToPeersList
+}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler.AddPeer
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PieceDownloader.PieceDownloaded
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.util.Random
+
+class FileTorrentDownloader(torrent: Torrent, storageFile: File)
+    extends Actor
+    with ActorLogging
+    with Timers {
+  override def supervisorStrategy: SupervisorStrategy =
+    OneForOneStrategy() {
+      case _: Exception => Restart
+    }
+
+  val peerId = {
+    val prefix = ByteString("--SY0001--")
+    val array = Array.fill[Byte](20 - prefix.length)(0)
+    Random.nextBytes(array)
+    prefix ++ ByteString(array)
+  }
+  val tracker = context.actorOf(
+    Tracker.props(torrent.announce, torrent.infoHash),
+    "tracker")
+  val swarm = context.actorOf(
+    PeerSwarmHandler.props(ByteString(torrent.infoHash.toArray),
+                           peerId,
+                           torrent.pieceHashes.size),
+    "swarm")
+
+  var remainingPieces: Set[Int] = torrent.pieceHashes.indices.toSet
+  val pieceByActor = mutable.Map.empty[ActorRef, Int]
+
+  timers.startPeriodicTimer(RespawnDownloadsTimer,
+                            RespawnDownloads,
+                            RespawnEvery)
+
+  override def preStart(): Unit = {
+    tracker ! SubscribeToPeersList
+    tracker ! GetPeers
+  }
+
+  override def receive: Receive = {
+    case PieceDownloaded(pieceId, data) =>
+      pieceByActor.get(sender()) match {
+        case Some(expectedPieceId) =>
+          pieceByActor -= sender()
+          require(expectedPieceId == pieceId)
+          context.unwatch(sender())
+          savePiece(pieceId, data)
+          spawnDownloaders()
+        case None =>
+          log.info(
+            s"Unexpected PieceDownloaded for piece $pieceId from ${sender()}")
+      }
+    case Terminated(actor) =>
+      pieceByActor.get(sender()) match {
+        case Some(pieceId) =>
+          pieceByActor -= sender()
+          log.info(
+            s"PieceDownloader for piece $pieceId terminated, adding it back to the queue")
+          remainingPieces += pieceId
+          spawnDownloaders()
+        case None =>
+          log.info(s"Unknown actor terminated: ${sender()}")
+      }
+      spawnDownloaders()
+    case PeersListResponse(peers) =>
+      peers.foreach(swarm ! AddPeer(_))
+      spawnDownloaders()
+    case RespawnDownloads =>
+      spawnDownloaders()
+  }
+
+  def spawnDownloaders(): Unit = {
+    while (remainingPieces.nonEmpty && pieceByActor.size < MaxPiecesSimultaneously) {
+      // TODO: choose the rarest piece first
+      val id = remainingPieces.toSeq(Random.nextInt(remainingPieces.size))
+      remainingPieces = remainingPieces - id
+
+      val actor = context.actorOf(
+        PieceDownloader
+          .props(swarm, id, torrent.pieceLength(id), torrent.pieceHashes(id)),
+        s"piece-$id")
+      context.watch(actor)
+      pieceByActor(actor) = id
+    }
+    if (remainingPieces.isEmpty && pieceByActor.isEmpty) {
+      log.debug("Download completed, nothing to span")
+    }
+  }
+
+  def savePiece(pieceId: Int, data: ByteString): Unit = {
+    require(data.length == torrent.pieceLength(pieceId))
+    val f = new RandomAccessFile(storageFile, "rws")
+    try {
+      f.seek(pieceId * torrent.basePieceLength)
+      f.write(data.toArray)
+    } finally {
+      f.close()
+    }
+    log.debug(s"Saved piece $pieceId to $storageFile")
+  }
+}
+
+object FileTorrentDownloader {
+  private val MaxPiecesSimultaneously = 10
+  private val RespawnEvery = 5.seconds
+
+  def props(torrent: Torrent, storageFile: File): Props =
+    Props(new FileTorrentDownloader(torrent, storageFile))
+
+  private case object RespawnDownloadsTimer
+  private case object RespawnDownloads
+}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
@@ -126,7 +126,7 @@ class FileTorrentDownloader(torrent: Torrent, storageFile: File)
     } finally {
       f.close()
     }
-    log.debug(s"Saved piece $pieceId to $storageFile")
+    log.debug(s"Saved piece $pieceId to $storageFile, ${pieceByActor.size} are downloading, ${remainingPieces.size} are in queue")
     if (remainingPieces.isEmpty && pieceByActor.isEmpty) {
       log.info("Download completed")
     }

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
@@ -127,6 +127,9 @@ class FileTorrentDownloader(torrent: Torrent, storageFile: File)
       f.close()
     }
     log.debug(s"Saved piece $pieceId to $storageFile")
+    if (remainingPieces.isEmpty && pieceByActor.isEmpty) {
+      log.info("Download completed")
+    }
   }
 }
 

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/FileTorrentDownloader.scala
@@ -113,7 +113,7 @@ class FileTorrentDownloader(torrent: Torrent, storageFile: File)
       pieceByActor(actor) = id
     }
     if (remainingPieces.isEmpty && pieceByActor.isEmpty) {
-      log.debug("Download completed, nothing to span")
+      log.debug("Download completed, nothing to spawn")
     }
   }
 

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/Torrent.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/Torrent.scala
@@ -1,0 +1,50 @@
+package net.yeputons.spbau.fall2017.scala.torrentclient
+
+import java.security.MessageDigest
+
+import akka.http.scaladsl.model.Uri
+import net.yeputons.spbau.fall2017.scala.torrentclient.bencode._
+
+case class Torrent(announce: Uri,
+                   infoHash: Seq[Byte],
+                   pieceLength: Int,
+                   pieceHashes: Seq[Seq[Byte]],
+                   fileLength: Long)
+
+object Torrent {
+  def apply(torrentFile: BEntry): Torrent = {
+    import BEntry.Conversions
+    val torrentData: BDict = torrentFile.getDict
+
+    val announceBytes = torrentData("announce").getByteString.toArray
+    val announce = Uri(new String(announceBytes, "UTF-8"))
+
+    val info = torrentData("info").getDict
+    val infoHash: Array[Byte] = MessageDigest
+      .getInstance("SHA-1")
+      .digest(BencodeEncoder(info).toArray)
+
+    val pieceLength = info("piece length").getNumber.toInt
+
+    val pieces = info("pieces").getByteString
+    require(pieces.length % 20 == 0)
+    val pieceHashes = pieces.grouped(20).toSeq
+
+    val fileLength = info("length").getNumber
+
+    Torrent(announce, infoHash, pieceLength, pieceHashes, fileLength)
+  }
+
+  def apply(torrentBytes: Seq[Byte]): Torrent = {
+    val torrentFile = BencodeDecoder(torrentBytes) match {
+      case Right(data) => data
+      case Left(msg) =>
+        throw new IllegalArgumentException(s"Invalid .torrent data: $msg")
+    }
+    if (BencodeEncoder(torrentFile) != torrentBytes) {
+      throw new IllegalArgumentException(
+        ".torrent data is not a canonical Bencode")
+    }
+    Torrent(torrentFile)
+  }
+}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/Tracker.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/Tracker.scala
@@ -50,8 +50,8 @@ class Tracker(baseAnnounceUri: Uri,
   }
 
   override def receive: Receive = {
-    case GetPeers(requestId) =>
-      sender() ! PeersListResponse(requestId, peers)
+    case GetPeers =>
+      sender() ! PeersListResponse(peers)
     case UpdatePeersList =>
       updatePeersList()
     case HttpRequestSucceeded(_, httpResponse, data) =>
@@ -161,9 +161,8 @@ object Tracker {
 
   /**
     * Request for the [[Tracker]] actor to send a current list of peers
-    * @param requestId An arbitrary number to tell requests sent at different moments apart
     */
-  case class GetPeers(requestId: Long)
+  case object GetPeers
 
   /**
     * Request for the [[Tracker]] actor to update list of peers from the tracker.
@@ -172,10 +171,9 @@ object Tracker {
 
   /**
     * Response for the [[GetPeers]] message.
-    * @param requestId The same `requestId` as provided in the initial [[GetPeers]] message
     * @param peers Current list of peers
     */
-  case class PeersListResponse(requestId: Long, peers: Set[PeerInformation])
+  case class PeersListResponse(peers: Set[PeerInformation])
 
   /**
     * Creates [[Props]] for the [[Tracker]] actor.

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/DownloadTorrentApp.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/DownloadTorrentApp.scala
@@ -1,0 +1,53 @@
+package net.yeputons.spbau.fall2017.scala.torrentclient.apps
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import akka.actor.{ActorSystem, PoisonPill}
+import akka.pattern.ask
+import akka.util.{ByteString, Timeout}
+import net.yeputons.spbau.fall2017.scala.torrentclient.{FileTorrentDownloader, Torrent, Tracker}
+import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.{GetPeers, PeerInformation, PeersListResponse}
+import net.yeputons.spbau.fall2017.scala.torrentclient.apps.ShowPeersForTorrentApp.getClass
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler._
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration.{Duration, _}
+
+object DownloadTorrentApp {
+  val log = LoggerFactory.getLogger(getClass)
+  implicit val executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.global
+
+  def main(args: Array[String]): Unit = {
+    if (args.length != 2) {
+      System.err.println(
+        """
+          |Expected arguments: <path-to-torrent-file> <output-file>
+          |
+          |This test app parses a .torrent file and tries to download it
+          |to a specific file.
+        """.stripMargin)
+      sys.exit(1)
+    }
+    val torrentBytes: Array[Byte] = Files.readAllBytes(Paths.get(args(0)))
+    val torrent: Torrent = Torrent(torrentBytes)
+    val storageFile = new File(args(1))
+    if (!storageFile.exists()) {
+      if (!storageFile.createNewFile()) {
+        System.err.println(s"Cannot create new file at $storageFile")
+        sys.exit(1)
+      }
+    }
+    if (!storageFile.canWrite) {
+      System.err.println(s"Cannot write to $storageFile")
+      sys.exit(1)
+    }
+
+    val actorSystem = ActorSystem("download-torrent")
+    val downloader = actorSystem.actorOf(FileTorrentDownloader.props(torrent, storageFile), "torrent")
+    // Do not terminate the actor system
+  }
+}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
@@ -3,7 +3,7 @@ package net.yeputons.spbau.fall2017.scala.torrentclient.apps
 import java.nio.file.{Files, Path, Paths}
 import java.security.MessageDigest
 
-import akka.actor.{ActorSystem, PoisonPill}
+import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.pattern.ask
 import akka.http.scaladsl.model.Uri
 import akka.util.{ByteString, Timeout}
@@ -79,7 +79,8 @@ object ShowPeersForTorrentApp {
     peers.foreach { peer =>
       System.out.println(f"Connecting to $peer...")
       val peerActor = actorSystem.actorOf(
-        PeerHandler.props(ByteString(infoHash),
+        PeerHandler.props(ActorRef.noSender,
+                          ByteString(infoHash),
                           ByteString("01234567890123456789"),
                           peer),
         java.net.URLEncoder.encode(peer.address.getHostString, "ASCII") +

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
@@ -8,25 +8,18 @@ import akka.pattern.ask
 import akka.http.scaladsl.model.Uri
 import akka.util.{ByteString, Timeout}
 import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker
-import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.{
-  GetPeers,
-  PeerInformation,
-  PeersListResponse
-}
+import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.{GetPeers, PeerInformation, PeersListResponse}
 import net.yeputons.spbau.fall2017.scala.torrentclient.bencode._
-import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler.{
-  AddPeer,
-  PieceStatisticsRequest,
-  PieceStatisticsResponse
-}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler._
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.{Duration, _}
 
 object ShowPeersForTorrentApp {
   val log = LoggerFactory.getLogger(getClass)
+  implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
 
   def main(args: Array[String]): Unit = {
     if (args.length != 1) {
@@ -117,6 +110,9 @@ object ShowPeersForTorrentApp {
             s"${piecesOfPeer.values.min} and ${piecesOfPeer.values.max} pieces, " +
             s"average is ${piecesOfPeer.values.sum / piecesOfPeer.values.size}"
         )
+      }
+      (swarm ? PeerForPieceRequest(0)).map { case PeerForPieceResponse(0, peer) =>
+          log.info(s"Current peer for piece 0 is $peer")
       }
     }
 

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
@@ -1,9 +1,9 @@
 package net.yeputons.spbau.fall2017.scala.torrentclient.apps
 
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.security.MessageDigest
 
-import akka.actor.{ActorRef, ActorSystem, PoisonPill}
+import akka.actor.{ActorSystem, PoisonPill}
 import akka.pattern.ask
 import akka.http.scaladsl.model.Uri
 import akka.util.{ByteString, Timeout}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/apps/ShowPeersForTorrentApp.scala
@@ -50,8 +50,8 @@ object ShowPeersForTorrentApp {
     while (peers.isEmpty) {
       Thread.sleep(1000)
       val id = random.nextLong()
-      Await.result(tracker ? GetPeers(id), Duration.Inf) match {
-        case PeersListResponse(`id`, newPeers) =>
+      Await.result(tracker ? GetPeers, Duration.Inf) match {
+        case PeersListResponse(newPeers) =>
           peers = newPeers
       }
     }

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/bencode/Bencode.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/bencode/Bencode.scala
@@ -80,3 +80,35 @@ object BDict {
 
   def empty: BDict = BDict(Map.empty[immutable.Seq[Byte], BEntry])
 }
+
+object BEntry {
+  implicit class Conversions(entry: BEntry) {
+    def getByteString: Seq[Byte] = entry match {
+      case BByteString(value) => value
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected BByteString, found ${entry.getClass}")
+    }
+
+    def getNumber: Long = entry match {
+      case BNumber(value) => value
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected BNumber, found ${entry.getClass}")
+    }
+
+    def getList: BList = entry match {
+      case l: BList => l
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected BList, found ${entry.getClass}")
+    }
+
+    def getDict: BDict = entry match {
+      case x: BDict => x
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected BDict, found ${entry.getClass}")
+    }
+  }
+}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerConnection.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerConnection.scala
@@ -57,16 +57,16 @@ abstract class PeerConnection(handler: ActorRef)
     case akka.actor.Status.Failure(e) =>
       e match {
         case e: StreamTcpException =>
-          log.warning(s"TCP error, aborting: $e")
+          log.info(s"TCP error, aborting: $e")
         case _ =>
-          log.warning(f"Peer protocol error occurred, aborting connection: $e")
+          log.info(f"Peer protocol error occurred, aborting connection: $e")
       }
       context.stop(self)
     case PeerConnection.OnCompleteMessage =>
       log.info("Stream terminated, stopping")
       context.stop(self)
     case Terminated(`connection`) =>
-      log.warning("Connection actor stopped, stopping")
+      log.info("Connection actor stopped, stopping")
       context.stop(self)
   }
 

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -22,8 +22,12 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
   val actorByPeer = mutable.Map.empty[PeerInformation, ActorRef]
   val peerByActor = mutable.Map.empty[ActorRef, PeerInformation]
 
-  val actorsWithPiece = mutable.Map.empty[Int, mutable.Set[ActorRef]].withDefaultValue(mutable.Set.empty)
-  val piecesOfActor = mutable.Map.empty[ActorRef, mutable.Set[Int]].withDefaultValue(mutable.Set.empty)
+  val actorsWithPiece = mutable.Map
+    .empty[Int, mutable.Set[ActorRef]]
+    .withDefaultValue(mutable.Set.empty)
+  val piecesOfActor = mutable.Map
+    .empty[ActorRef, mutable.Set[Int]]
+    .withDefaultValue(mutable.Set.empty)
 
   def createPeerActor(peer: PeerInformation): ActorRef
 

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -18,8 +18,8 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
   val actorByPeer = mutable.Map.empty[PeerInformation, ActorRef]
   val peerByActor = mutable.Map.empty[ActorRef, PeerInformation]
 
-  val actorsWithPiece = mutable.Map.empty[Int, mutable.Set[ActorRef]]
-  val piecesOfActor = mutable.Map.empty[ActorRef, mutable.Set[Int]]
+  val actorsWithPiece = mutable.Map.empty[Int, mutable.Set[ActorRef]].withDefaultValue(mutable.Set.empty)
+  val piecesOfActor = mutable.Map.empty[ActorRef, mutable.Set[Int]].withDefaultValue(mutable.Set.empty)
 
   def createActor(peer: PeerInformation): ActorRef
 
@@ -58,7 +58,9 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
       log.debug(s"Actor for $peer terminated")
       actorByPeer -= peer
       peerByActor -= actor
-      piecesOfActor(actor).foreach(actorsWithPiece(_) -= actor)
+      piecesOfActor.get(actor).foreach { pieces =>
+        pieces.foreach(actorsWithPiece(_) -= actor)
+      }
       piecesOfActor -= actor
 
     case PieceStatisticsRequest =>

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -21,7 +21,7 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
   val actorsWithPiece = mutable.Map.empty[Int, mutable.Set[ActorRef]].withDefaultValue(mutable.Set.empty)
   val piecesOfActor = mutable.Map.empty[ActorRef, mutable.Set[Int]].withDefaultValue(mutable.Set.empty)
 
-  def createActor(peer: PeerInformation): ActorRef
+  def createPeerActor(peer: PeerInformation): ActorRef
 
   override def supervisorStrategy: SupervisorStrategy =
     OneForOneStrategy() {
@@ -32,7 +32,7 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
     case AddPeer(peer) =>
       if (!actorByPeer.contains(peer)) {
         log.debug(s"Creating new actor for $peer")
-        val actor = createActor(peer)
+        val actor = createPeerActor(peer)
         actorByPeer += peer -> actor
         peerByActor += actor -> peer
         context.watch(actor)

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -1,0 +1,78 @@
+package net.yeputons.spbau.fall2017.scala.torrentclient.peer
+
+import akka.actor.SupervisorStrategy.Stop
+import akka.actor.{
+  Actor,
+  ActorLogging,
+  ActorRef,
+  OneForOneStrategy,
+  SupervisorStrategy,
+  Terminated
+}
+import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.PeerInformation
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler._
+
+import scala.collection.mutable
+
+abstract class PeerSwarmHandler extends Actor with ActorLogging {
+  val actorByPeer = mutable.Map.empty[PeerInformation, ActorRef]
+  val peerByActor = mutable.Map.empty[ActorRef, PeerInformation]
+
+  val actorsWithPiece = mutable.Map.empty[Int, mutable.Set[ActorRef]]
+  val piecesOfActor = mutable.Map.empty[ActorRef, mutable.Set[Int]]
+
+  def createActor(peer: PeerInformation): ActorRef
+
+  override def supervisorStrategy: SupervisorStrategy =
+    OneForOneStrategy() {
+      case _: Exception => Stop
+    }
+
+  override def receive: Receive = {
+    case AddPeer(peer) =>
+      if (!actorByPeer.contains(peer)) {
+        log.debug(s"Creating new actor for $peer")
+        val actor = createActor(peer)
+        actorByPeer += peer -> actor
+        peerByActor += actor -> peer
+        context.watch(actor)
+      }
+    case AddPieces(pieces) =>
+      val actor = sender()
+      if (peerByActor.contains(actor)) {
+        piecesOfActor(actor) ++= pieces
+        pieces.foreach(actorsWithPiece(_) += actor)
+      } else {
+        log.debug(s"Unexpected AddPieces message from $actor")
+      }
+    case RemovePieces(pieces) =>
+      val actor = sender()
+      if (peerByActor.contains(actor)) {
+        piecesOfActor(actor) --= pieces
+        pieces.foreach(actorsWithPiece(_) -= actor)
+      } else {
+        log.debug(s"Unexpected RemovePieces message from $actor")
+      }
+    case Terminated(actor) =>
+      val peer = peerByActor(actor)
+      log.debug(s"Actor for $peer terminated")
+      actorByPeer -= peer
+      peerByActor -= actor
+      piecesOfActor(actor).foreach(actorsWithPiece(_) -= actor)
+      piecesOfActor -= actor
+
+    case PieceStatisticsRequest =>
+      sender() ! PieceStatisticsResponse(actorsWithPiece.map {
+        case (piece, actors) => (piece, actors.size)
+      }.toMap)
+  }
+}
+
+object PeerSwarmHandler {
+  case class AddPeer(peer: PeerInformation)
+  case class AddPieces(pieces: Set[Int])
+  case class RemovePieces(pieces: Set[Int])
+  case object PieceStatisticsRequest
+
+  case class PieceStatisticsResponse(actorsWithPiece: Map[Int, Int])
+}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -3,15 +3,7 @@ package net.yeputons.spbau.fall2017.scala.torrentclient.peer
 import java.net.URLEncoder
 
 import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{
-  Actor,
-  ActorLogging,
-  ActorRef,
-  OneForOneStrategy,
-  Props,
-  SupervisorStrategy,
-  Terminated
-}
+import akka.actor._
 import akka.util.ByteString
 import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.PeerInformation
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler._

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -53,7 +53,7 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
       }
     case Terminated(actor) =>
       val peer = peerByActor(actor)
-      log.debug(s"Actor for $peer terminated, ${actorByPeer.size} peers left")
+      log.debug(s"Actor for $peer terminated, ${actorByPeer.size - 1} peers left")
       actorByPeer -= peer
       peerByActor -= actor
       piecesOfActor.get(actor).foreach { pieces =>

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerSwarmHandler.scala
@@ -72,6 +72,11 @@ abstract class PeerSwarmHandler extends Actor with ActorLogging {
         }.toMap
       )
   }
+
+  override def unhandled(message: Any): Unit = {
+    log.error(s"Unhandled message, stopping: $message")
+    context.stop(self)
+  }
 }
 
 object PeerSwarmHandler {

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
@@ -1,0 +1,108 @@
+package net.yeputons.spbau.fall2017.scala.torrentclient.peer
+
+import java.security.MessageDigest
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
+import akka.util.ByteString
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerHandler.{BlockDownloaded, DownloadBlock}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler.{PeerForPieceRequest, PeerForPieceResponse}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PieceDownloader._
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.protocol.PeerMessage.BlockId
+
+import scala.collection.mutable
+
+class PieceDownloader(peerSwarmHandler: ActorRef,
+                      pieceId: Int,
+                      pieceLength: Int,
+                      pieceHash: Seq[Byte])
+    extends Actor
+    with ActorLogging {
+
+  val blocksCount = (pieceLength + BlockSize - 1) / BlockSize
+  val blockIds = (0 until blocksCount).map { blockId =>
+    val blockStart = blockId * BlockSize
+    val blockEnd = math.min(blockStart + BlockSize, pieceLength)
+    BlockId(pieceId = pieceId, begin = blockStart, blockEnd - blockStart)
+  }
+  val blocks: mutable.Seq[Option[ByteString]] = mutable.Seq.fill(blocksCount)(Option.empty[ByteString])
+
+  var peer = Option.empty[ActorRef]
+
+  override def preStart(): Unit = {
+    choosePeer()
+    context.watch(peerSwarmHandler)
+  }
+
+  override def receive: Receive = {
+    case Terminated(`peerSwarmHandler`) =>
+      throw new IllegalStateException("PeerSwarmHandler terminated")
+    case Terminated(terminatedPeer) =>
+      if (peer.isDefined && peer.get == terminatedPeer) {
+        log.debug(s"Peer died, choosing another one")
+        choosePeer()
+      } else {
+        log.debug(s"Unexpected peer terminated message: got $terminatedPeer, my current peer is $peer")
+      }
+    case PeerForPieceResponse(`pieceId`, newPeer) =>
+      peer = Some(newPeer)
+      log.debug(s"Will try downloading piece $pieceId from $newPeer")
+      blocks.zip(blockIds).foreach {
+        case (None, blockId) =>
+          newPeer ! DownloadBlock(blockId)
+        case (_, _) =>
+      }
+    case BlockDownloaded(blockId @ BlockId(`pieceId`, begin, length), data) =>
+      val id = begin / BlockSize
+      if (blockId != blockIds(id)) {
+        throw new IllegalArgumentException(s"Invalid BlockDownloaded message: expected ${blockIds(id)}, got $blockId")
+      }
+      blocks(id) = Some(data)
+      checkBlocks()
+  }
+
+  def checkBlocks(): Unit = {
+    if (blocks.contains(None)) {
+      return
+    }
+    val digest = MessageDigest.getInstance("SHA-1")
+    blocks.foreach {
+      case Some(data) => digest.update(data.asByteBuffer)
+      case None => require(false)
+    }
+    val realHash = digest.digest().toSeq
+    if (pieceHash == realHash) {
+      log.debug(s"Successfully downloaded piece $pieceId")
+      context.parent ! PieceDownloaded(pieceId, blocks.map(_.get).reduce(_ ++ _))
+      context.stop(self)
+    }
+    log.warning(
+      s"Downloaded piece $pieceId of length $pieceLength with an invalid hash: got $realHash instead of $pieceHash, retrying")
+    for (i <- 0 to blocks.size)
+      blocks(i) = None
+    choosePeer()
+  }
+
+  def choosePeer(): Unit = {
+    log.debug("Choosing new peer for downloading piece $pieceId")
+    peer = None
+    peerSwarmHandler ! PeerForPieceRequest(pieceId)
+  }
+
+  override def unhandled(message: Any): Unit = {
+    log.error(s"Unhandled message, stopping: $message")
+    context.stop(self)
+  }
+}
+
+object PieceDownloader {
+  val BlockSize: Int = 1 << 14
+
+  case class PieceDownloaded(pieceId: Int, data: ByteString)
+
+  def props(peerSwarmHandler: ActorRef,
+            pieceId: Int,
+            pieceLength: Int,
+            pieceHash: Seq[Byte]): Props =
+    Props(
+      new PieceDownloader(peerSwarmHandler, pieceId, pieceLength, pieceHash))
+}

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
@@ -2,21 +2,29 @@ package net.yeputons.spbau.fall2017.scala.torrentclient.peer
 
 import java.security.MessageDigest
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated, Timers}
 import akka.util.ByteString
-import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerHandler.{BlockDownloaded, DownloadBlock}
-import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler.{PeerForPieceRequest, PeerForPieceResponse}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerHandler.{
+  BlockDownloaded,
+  DownloadBlock
+}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler.{
+  PeerForPieceRequest,
+  PeerForPieceResponse
+}
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PieceDownloader._
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.protocol.PeerMessage.BlockId
 
 import scala.collection.mutable
+import scala.concurrent.duration._
 
 class PieceDownloader(peerSwarmHandler: ActorRef,
                       pieceId: Int,
                       pieceLength: Int,
                       pieceHash: Seq[Byte])
     extends Actor
-    with ActorLogging {
+    with ActorLogging
+    with Timers {
 
   val blocksCount = (pieceLength + BlockSize - 1) / BlockSize
   val blockIds = (0 until blocksCount).map { blockId =>
@@ -24,13 +32,14 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
     val blockEnd = math.min(blockStart + BlockSize, pieceLength)
     BlockId(pieceId = pieceId, begin = blockStart, blockEnd - blockStart)
   }
-  val blocks: mutable.Seq[Option[ByteString]] = mutable.Seq.fill(blocksCount)(Option.empty[ByteString])
+  val blocks: mutable.Seq[Option[ByteString]] =
+    mutable.Seq.fill(blocksCount)(Option.empty[ByteString])
 
   var peer = Option.empty[ActorRef]
 
   override def preStart(): Unit = {
-    choosePeer()
     context.watch(peerSwarmHandler)
+    choosePeer()
   }
 
   override def receive: Receive = {
@@ -38,11 +47,16 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
       throw new IllegalStateException("PeerSwarmHandler terminated")
     case Terminated(terminatedPeer) =>
       if (peer.isDefined && peer.get == terminatedPeer) {
-        log.debug(s"Peer died, choosing another one")
+        log.debug("Peer died, choosing another one")
         choosePeer()
       } else {
-        log.debug(s"Unexpected peer terminated message: got $terminatedPeer, my current peer is $peer")
+        log.debug(
+          s"Unexpected peer terminated message: got $terminatedPeer, my current peer is $peer")
       }
+    case NoBlocksTimedOut =>
+      log.debug(
+        "No blocks received from the peer for a while, choosing another one")
+      choosePeer()
     case PeerForPieceResponse(`pieceId`, newPeer) =>
       peer = Some(newPeer)
       log.debug(s"Will try downloading piece $pieceId from $newPeer")
@@ -54,9 +68,13 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
     case BlockDownloaded(blockId @ BlockId(`pieceId`, begin, length), data) =>
       val id = begin / BlockSize
       if (blockId != blockIds(id)) {
-        throw new IllegalArgumentException(s"Invalid BlockDownloaded message: expected ${blockIds(id)}, got $blockId")
+        throw new IllegalArgumentException(
+          s"Invalid BlockDownloaded message: expected ${blockIds(id)}, got $blockId")
       }
       blocks(id) = Some(data)
+      timers.startSingleTimer(NoBlocksTimeoutTimer,
+                              NoBlocksTimedOut,
+                              NoBlocksTimeout)
       checkBlocks()
   }
 
@@ -67,12 +85,13 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
     val digest = MessageDigest.getInstance("SHA-1")
     blocks.foreach {
       case Some(data) => digest.update(data.asByteBuffer)
-      case None => require(false)
+      case None       => require(false)
     }
     val realHash = digest.digest().toSeq
     if (pieceHash == realHash) {
       log.debug(s"Successfully downloaded piece $pieceId")
-      context.parent ! PieceDownloaded(pieceId, blocks.map(_.get).reduce(_ ++ _))
+      context.parent ! PieceDownloaded(pieceId,
+                                       blocks.map(_.get).reduce(_ ++ _))
       context.stop(self)
     }
     log.warning(
@@ -83,9 +102,12 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
   }
 
   def choosePeer(): Unit = {
-    log.debug("Choosing new peer for downloading piece $pieceId")
+    log.debug(s"Choosing new peer for downloading piece $pieceId")
     peer = None
     peerSwarmHandler ! PeerForPieceRequest(pieceId)
+    timers.startSingleTimer(NoBlocksTimeoutTimer,
+                            NoBlocksTimedOut,
+                            NoBlocksTimeout)
   }
 
   override def unhandled(message: Any): Unit = {
@@ -96,6 +118,7 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
 
 object PieceDownloader {
   val BlockSize: Int = 1 << 14
+  val NoBlocksTimeout = 10.seconds
 
   case class PieceDownloaded(pieceId: Int, data: ByteString)
 
@@ -105,4 +128,7 @@ object PieceDownloader {
             pieceHash: Seq[Byte]): Props =
     Props(
       new PieceDownloader(peerSwarmHandler, pieceId, pieceLength, pieceHash))
+
+  case object NoBlocksTimeoutTimer
+  case object NoBlocksTimedOut
 }

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
@@ -66,6 +66,7 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
         case (_, _) =>
       }
     case BlockDownloaded(blockId @ BlockId(`pieceId`, begin, length), data) =>
+      // TODO: update tracker statistics
       val id = begin / BlockSize
       if (blockId != blockIds(id)) {
         throw new IllegalArgumentException(

--- a/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
+++ b/src/main/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PieceDownloader.scala
@@ -93,10 +93,11 @@ class PieceDownloader(peerSwarmHandler: ActorRef,
       context.parent ! PieceDownloaded(pieceId,
                                        blocks.map(_.get).reduce(_ ++ _))
       context.stop(self)
+      return
     }
     log.warning(
       s"Downloaded piece $pieceId of length $pieceLength with an invalid hash: got $realHash instead of $pieceHash, retrying")
-    for (i <- 0 to blocks.size)
+    for (i <- blocks.indices)
       blocks(i) = None
     choosePeer()
   }

--- a/src/test/scala/net/yeputons/spbau/fall2017/scala/torrentclient/TrackerSpec.scala
+++ b/src/test/scala/net/yeputons/spbau/fall2017/scala/torrentclient/TrackerSpec.scala
@@ -51,8 +51,8 @@ class TrackerSpec
   "The Tracker actor" must {
     "answer with no peers in the beginning" in {
       val tracker = createTracker(Uri./, TestProbe().ref)
-      tracker ! GetPeers(123)
-      expectMsg(1.second, PeersListResponse(123, Set.empty))
+      tracker ! GetPeers
+      expectMsg(1.second, PeersListResponse(Set.empty))
       tracker ! PoisonPill
     }
 
@@ -110,10 +110,9 @@ class TrackerSpec
             )
           )
         )))
-      tracker ! GetPeers(514)
+      tracker ! GetPeers
       val msg = expectMsgClass(1.second, classOf[PeersListResponse])
       msg shouldBe PeersListResponse(
-        514,
         Set(
           PeerInformation(InetSocketAddress.createUnresolved("1.example.com",
                                                              4567),
@@ -143,10 +142,9 @@ class TrackerSpec
                 Seq(127, 1, 2, 5, 0x1F, 0x90)).map(_.toByte)
             )
           )))
-      tracker ! GetPeers(514)
+      tracker ! GetPeers
       val msg = expectMsgClass(1.second, classOf[PeersListResponse])
       msg shouldBe PeersListResponse(
-        514,
         Set(
           PeerInformation(new InetSocketAddress("127.1.2.3", 8080), None),
           PeerInformation(new InetSocketAddress("127.1.2.3", 8081), None),

--- a/src/test/scala/net/yeputons/spbau/fall2017/scala/torrentclient/TrackerSpec.scala
+++ b/src/test/scala/net/yeputons/spbau/fall2017/scala/torrentclient/TrackerSpec.scala
@@ -6,15 +6,8 @@ import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.http.scaladsl.model._
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.ByteString
-import net.yeputons.spbau.fall2017.scala.torrentclient.HttpRequestActor.{
-  HttpRequestSucceeded,
-  MakeHttpRequest
-}
-import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.{
-  GetPeers,
-  PeerInformation,
-  PeersListResponse
-}
+import net.yeputons.spbau.fall2017.scala.torrentclient.HttpRequestActor.{HttpRequestSucceeded, MakeHttpRequest}
+import net.yeputons.spbau.fall2017.scala.torrentclient.Tracker.{GetPeers, PeerInformation, PeersListResponse, SubscribeToPeersList}
 import net.yeputons.spbau.fall2017.scala.torrentclient.bencode._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -88,7 +81,10 @@ class TrackerSpec
 
     "parses list of peers in verbose representation" in {
       val httpRequestProbe = TestProbe()
+      val subscribedActor = TestProbe()
+
       val tracker = createTracker("/", httpRequestProbe.ref)
+      subscribedActor.send(tracker, SubscribeToPeersList)
       httpRequestProbe.expectMsgClass(1.second, classOf[MakeHttpRequest])
       httpRequestProbe.reply(
         successfulHttpResponse(BDict.fromAsciiStringKeys(
@@ -110,27 +106,31 @@ class TrackerSpec
             )
           )
         )))
+
+      val response = PeersListResponse(Set(
+        PeerInformation(InetSocketAddress.createUnresolved("1.example.com",
+                                                           4567),
+                        Some("peer-123".getBytes().toSeq)),
+        PeerInformation(InetSocketAddress.createUnresolved("2.example.com",
+                                                           4568),
+                        Some("peer-456".getBytes().toSeq)),
+        PeerInformation(InetSocketAddress.createUnresolved("3.example.com",
+                                                           4569),
+                        None)
+      ))
+      subscribedActor.expectMsgClass(1.seconds, classOf[PeersListResponse]) shouldBe response
+
       tracker ! GetPeers
-      val msg = expectMsgClass(1.second, classOf[PeersListResponse])
-      msg shouldBe PeersListResponse(
-        Set(
-          PeerInformation(InetSocketAddress.createUnresolved("1.example.com",
-                                                             4567),
-                          Some("peer-123".getBytes().toSeq)),
-          PeerInformation(InetSocketAddress.createUnresolved("2.example.com",
-                                                             4568),
-                          Some("peer-456".getBytes().toSeq)),
-          PeerInformation(InetSocketAddress.createUnresolved("3.example.com",
-                                                             4569),
-                          None)
-        )
-      )
+      expectMsgClass(1.second, classOf[PeersListResponse]) shouldBe response
     }
 
     // BEP 23 "Tracker Returns Compact Peer Lists"
     "parses list of peers in compact representation" in {
       val httpRequestProbe = TestProbe()
+      val subscribedActor = TestProbe()
+
       val tracker = createTracker("/", httpRequestProbe.ref)
+      subscribedActor.send(tracker, SubscribeToPeersList)
       httpRequestProbe.expectMsgClass(1.second, classOf[MakeHttpRequest])
       httpRequestProbe.reply(
         successfulHttpResponse(
@@ -142,15 +142,16 @@ class TrackerSpec
                 Seq(127, 1, 2, 5, 0x1F, 0x90)).map(_.toByte)
             )
           )))
+
+      val response = PeersListResponse(Set(
+        PeerInformation(new InetSocketAddress("127.1.2.3", 8080), None),
+        PeerInformation(new InetSocketAddress("127.1.2.3", 8081), None),
+        PeerInformation(new InetSocketAddress("127.1.2.5", 8080), None)
+      ))
+      subscribedActor.expectMsgClass(1.seconds, classOf[PeersListResponse]) shouldBe response
       tracker ! GetPeers
-      val msg = expectMsgClass(1.second, classOf[PeersListResponse])
-      msg shouldBe PeersListResponse(
-        Set(
-          PeerInformation(new InetSocketAddress("127.1.2.3", 8080), None),
-          PeerInformation(new InetSocketAddress("127.1.2.3", 8081), None),
-          PeerInformation(new InetSocketAddress("127.1.2.5", 8080), None)
-        )
-      )
+
+      expectMsgClass(1.second, classOf[PeersListResponse]) shouldBe response
     }
   }
 }

--- a/src/test/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerHandlerSpec.scala
+++ b/src/test/scala/net/yeputons/spbau/fall2017/scala/torrentclient/peer/PeerHandlerSpec.scala
@@ -2,9 +2,14 @@ package net.yeputons.spbau.fall2017.scala.torrentclient.peer
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
+import akka.util.ByteString
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerConnection.{
   ReceivedPeerMessage,
   SendPeerMessage
+}
+import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerHandler.{
+  BlockDownloaded,
+  DownloadBlock
 }
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerHandlerSpec.PeerHandlerWithMock
 import net.yeputons.spbau.fall2017.scala.torrentclient.peer.PeerSwarmHandler.AddPieces
@@ -113,6 +118,87 @@ class PeerHandlerSpec
                  keepAliveTimeout = 500.milliseconds))
       watcher.watch(handler)
       watcher.expectTerminated(handler, 750.milliseconds)
+    }
+
+    "group block download requests and send answers" in {
+      val f = fixture
+      import f._
+
+      connection.expectNoMessage(100.milliseconds)
+
+      val actor1 = TestProbe()
+      val actor2 = TestProbe()
+      val block1 = BlockId(0, 0, 5)
+      val block2 = BlockId(0, 5, 3)
+      val block3 = BlockId(0, 8, 4)
+      val data1 = ByteString(0, 1, 2, 3, 4)
+      val data2 = ByteString(5, 6, 7)
+      val data3 = ByteString(8, 9, 10, 11)
+      actor1.send(handler, DownloadBlock(block1))
+      actor1.send(handler, DownloadBlock(block2))
+      actor2.send(handler, DownloadBlock(block1))
+      actor2.send(handler, DownloadBlock(block3))
+
+      connection.expectMsg(SendPeerMessage(Interested))
+      connection.expectNoMessage(100.milliseconds)
+
+      connection.send(handler, ReceivedPeerMessage(Unchoke))
+      connection.expectMsgAllOf(SendPeerMessage(BlockRequest(block1)),
+                                SendPeerMessage(BlockRequest(block2)),
+                                SendPeerMessage(BlockRequest(block3)))
+      connection.expectNoMessage(100.milliseconds)
+
+      connection.send(handler,
+                      ReceivedPeerMessage(BlockAvailable(block1, data1)))
+      actor1.expectMsg(BlockDownloaded(block1, data1))
+      actor2.expectMsg(BlockDownloaded(block1, data1))
+
+      connection.send(handler,
+                      ReceivedPeerMessage(BlockAvailable(block2, data2)))
+      actor2.expectNoMessage(100.milliseconds)
+      actor1.expectMsg(BlockDownloaded(block2, data2))
+
+      actor1.send(handler, DownloadBlock(block3))
+
+      connection.send(handler,
+                      ReceivedPeerMessage(BlockAvailable(block3, data3)))
+      actor1.expectMsg(BlockDownloaded(block3, data3))
+      actor2.expectMsg(BlockDownloaded(block3, data3))
+
+      connection.expectMsg(SendPeerMessage(NotInterested))
+    }
+
+    "abort block downloads when peer chokes and retry later" in {
+      val f = fixture
+      import f._
+
+      connection.expectNoMessage(100.milliseconds)
+
+      val actor1 = TestProbe()
+      val block1 = BlockId(0, 0, 5)
+      val data1 = ByteString(0, 1, 2, 3, 4)
+      actor1.send(handler, DownloadBlock(block1))
+
+      connection.expectMsg(SendPeerMessage(Interested))
+      connection.expectNoMessage(100.milliseconds)
+
+      connection.send(handler, ReceivedPeerMessage(Unchoke))
+      connection.expectMsg(SendPeerMessage(BlockRequest(block1)))
+      connection.expectNoMessage(100.milliseconds)
+
+      connection.send(handler, ReceivedPeerMessage(Choke))
+      connection.expectNoMessage(100.milliseconds)
+      actor1.expectNoMessage(100.milliseconds)
+
+      connection.send(handler, ReceivedPeerMessage(Unchoke))
+      connection.expectMsg(SendPeerMessage(BlockRequest(block1)))
+      connection.expectNoMessage(100.milliseconds)
+
+      connection.send(handler,
+        ReceivedPeerMessage(BlockAvailable(block1, data1)))
+      actor1.expectMsg(BlockDownloaded(block1, data1))
+
+      connection.expectMsg(SendPeerMessage(NotInterested))
     }
   }
 }


### PR DESCRIPTION
Third batch: managing swarm of peers, requesting blocks and pieces (see [here](https://wiki.theory.org/index.php/BitTorrentSpecification#Conventions)), saving that stuff to a file.

What works:
* `FileTorrentDownloader` was able to download a 10MB file in ~20 seconds from localhost to localhost. I've used Deluge as a seeder and [webtorrent/bittorrent-tracker](https://github.com/webtorrent/bittorrent-tracker) as a local tracker. Unfortunately, it looks like not all clients are compatible (e.g. some probably require extensions).
* It was able to download a 300MB `debian-9.3.0-amd64-netinst.iso ` file in 15 minutes. MD5 hash is correct after the download is completed, but not before. It used some "in-the-wild" tracker and seeders.

What is not implemented:
* Continuing a paused download. Basically, `FileTorrentDownloader` has to re-read the file and check which hashes are correct and which are not.
* Seeding.
* Sending statistics to the tracker.
* Showing statistics to the user. You can definitely see a lot of information in logs, but it's no UI.
* Tests for new big actors.
* Any kind of smart algorithms for choosing peer/piece/block.

What is not checked:
* How it crashes and restores. It didn't when I checked.

Next steps: hopefully, getting "5".